### PR TITLE
Fix high CPU usage

### DIFF
--- a/SyncRoomChatTool/Form1.cs
+++ b/SyncRoomChatTool/Form1.cs
@@ -1096,6 +1096,8 @@ namespace SyncRoomChatTool
             await Task.Run(async () => {
                 while (true)
                 {
+                    await Task.Delay(50);
+
                     if (CommentQue.Count < 1) { continue; }
                     CommentQue.TryTake(out CommentObject commentObj, 50);
                     if (commentObj == null)


### PR DESCRIPTION
## Description

CPU使用率が1スレッド100%近くになる現象があったため、当該箇所に小さな `Delay()` を挿入しました
(もう一桁小さくても充分かもしれません)

CPU Profiler (before this PR)
![c815e0aba357d759f04f699eb32b9ea8](https://github.com/dhamaoka/SyncRoomChatTool/assets/149823376/8b6b08f5-e85d-49f4-9bb9-85e0b717cb83)

## Proposed Changelog

TaskTryTakeAndSpeech()

## Impact range

TaskTryTakeAndSpeech()