### PR TITLE
Study of the perform `foreach` for the `new lines` given by `DiffMatchPatch` instead of the latest line

### DIFF
--- a/SyncRoomChatTool/packages.config
+++ b/SyncRoomChatTool/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="google-diff-match-patch" version="1.0.10" targetFramework="net472" />
   <package id="Microsoft.Win32.Registry" version="5.0.0" targetFramework="net472" />
   <package id="NAudio" version="2.2.1" targetFramework="net472" />
   <package id="NAudio.Asio" version="2.2.1" targetFramework="net472" />


### PR DESCRIPTION
Study of the perform `foreach` for the `new lines` given by `DiffMatchPatch` instead of the latest line

bug: Since all lines are `new lines` when this program is started, _all buffers in the SR chat window_ are read out. Discarding the buffer after startup might be better without taking diffs.