### PR TITLE
v0.0.2.1

### DIFF
--- a/SyncRoomChatTool/Form1.cs
+++ b/SyncRoomChatTool/Form1.cs
@@ -764,72 +764,76 @@ namespace SyncRoomChatTool
                                     //チャットログに変化があった場合。
                                     List<Diff> diffs = diffmatch.diff_main(oldLog, vp.Current.Value);
                                     diffmatch.diff_cleanupSemantic(diffs);
-                                    foreach (Diff result in diffs)
+
+                                    if ((diffs.Count > 0) && (!string.IsNullOrEmpty(oldLog)))
                                     {
-                                        if (result.operation == Operation.INSERT)
+                                        foreach (Diff result in diffs)
                                         {
-                                            string[] lines = result.text.Split(new string[] { "\n" }, StringSplitOptions.RemoveEmptyEntries);
-                                            foreach (string newComment in lines)
+                                            if (result.operation == Operation.INSERT)
                                             {
-                                                newDt = DateTime.Now;
-                                                CommentObject CommentObj = new CommentObject(newComment, oldComment, App.Default.canSpeech)
+                                                string[] lines = result.text.Split(new string[] { "\n" }, StringSplitOptions.RemoveEmptyEntries);
+                                                foreach (string newComment in lines)
                                                 {
-                                                    LastCommentTime = lastDt,
-                                                    NowCommentTime = newDt
-                                                };
-                                                if (string.IsNullOrEmpty(CommentObj.Comment) == false)
-                                                {
-                                                    //何かコメントあり。
-                                                    if (IsLogEmpty() == false)
+                                                    newDt = DateTime.Now;
+                                                    CommentObject CommentObj = new CommentObject(newComment, oldComment, App.Default.canSpeech)
                                                     {
-                                                        //かつ、リッチテキストボックスが空じゃない＝改行する。
-                                                        UpdateRichText(Environment.NewLine);
-                                                    }
-
-                                                    string addLine = CommentObj.UserName;
-                                                    if (string.IsNullOrEmpty(addLine) == false)
+                                                        LastCommentTime = lastDt,
+                                                        NowCommentTime = newDt
+                                                    };
+                                                    if (string.IsNullOrEmpty(CommentObj.Comment) == false)
                                                     {
-                                                        UpdateRichText(addLine);
-
-                                                        string separator = " ： ";
-                                                        if (CommentObj.IsLink)
+                                                        //何かコメントあり。
+                                                        if (IsLogEmpty() == false)
                                                         {
-                                                            //リンクだった時の処理
+                                                            //かつ、リッチテキストボックスが空じゃない＝改行する。
                                                             UpdateRichText(Environment.NewLine);
-                                                            addLine = " \t" + CommentObj.UriString;
                                                         }
-                                                        else
+
+                                                        string addLine = CommentObj.UserName;
+                                                        if (string.IsNullOrEmpty(addLine) == false)
                                                         {
-                                                            //リンクじゃない。
-                                                            //名前はもう出してるので、CommentObject.Commentじゃなく、RawComment を新たに作成。
-                                                            addLine = separator + CommentObj.RawComment;
+                                                            UpdateRichText(addLine);
+
+                                                            string separator = " ： ";
+                                                            if (CommentObj.IsLink)
+                                                            {
+                                                                //リンクだった時の処理
+                                                                UpdateRichText(Environment.NewLine);
+                                                                addLine = " \t" + CommentObj.UriString;
+                                                            }
+                                                            else
+                                                            {
+                                                                //リンクじゃない。
+                                                                //名前はもう出してるので、CommentObject.Commentじゃなく、RawComment を新たに作成。
+                                                                addLine = separator + CommentObj.RawComment;
+                                                            }
+
+                                                            UpdateRichText(addLine);
                                                         }
-
-                                                        UpdateRichText(addLine);
                                                     }
-                                                }
-                                                else
-                                                {
-                                                    //コメントなし。改行のみ。
-                                                    CommentObj.CanSpeech = false;
-                                                }
-
-                                                if (CommentObj.CanSpeech)
-                                                {
-                                                    //キューにぶっ込む。
-                                                    CommentQue.TryAdd(CommentObj);
-                                                }
-
-                                                oldComment = newComment;
-                                                lastDt = newDt;
-
-                                                bool existsFlg = VoiceLists.Exists(x => x.StyleId == CommentObj.StyleId);
-                                                if (existsFlg)
-                                                {
-                                                    //VoiceListsから、StyleIdその他の取り出し。
-                                                    foreach (var item in VoiceLists.Where(x => x.StyleId == CommentObj.StyleId))
+                                                    else
                                                     {
-                                                        UpdateStatusStrip(3, $"名前：{CommentObj.UserName} ボイス：[{item.StyleId}]{item.UserName}");
+                                                        //コメントなし。改行のみ。
+                                                        CommentObj.CanSpeech = false;
+                                                    }
+
+                                                    if (CommentObj.CanSpeech)
+                                                    {
+                                                        //キューにぶっ込む。
+                                                        CommentQue.TryAdd(CommentObj);
+                                                    }
+
+                                                    oldComment = newComment;
+                                                    lastDt = newDt;
+
+                                                    bool existsFlg = VoiceLists.Exists(x => x.StyleId == CommentObj.StyleId);
+                                                    if (existsFlg)
+                                                    {
+                                                        //VoiceListsから、StyleIdその他の取り出し。
+                                                        foreach (var item in VoiceLists.Where(x => x.StyleId == CommentObj.StyleId))
+                                                        {
+                                                            UpdateStatusStrip(3, $"名前：{CommentObj.UserName} ボイス：[{item.StyleId}]{item.UserName}");
+                                                        }
                                                     }
                                                 }
                                             }

--- a/SyncRoomChatTool/Properties/AssemblyInfo.cs
+++ b/SyncRoomChatTool/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // すべての値を指定するか、次を使用してビルド番号とリビジョン番号を既定に設定できます
 // 既定値にすることができます:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.0.2.0")]
-[assembly: AssemblyFileVersion("0.0.2.0")]
+[assembly: AssemblyVersion("0.0.2.1")]
+[assembly: AssemblyFileVersion("0.0.2.1")]

--- a/SyncRoomChatTool/SyncRoomChatTool.csproj
+++ b/SyncRoomChatTool/SyncRoomChatTool.csproj
@@ -55,6 +55,9 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="google-diff-match-patch, Version=1.0.10.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\google-diff-match-patch.1.0.10\lib\netstandard2.0\google-diff-match-patch.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Win32.Registry, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>packages\Microsoft.Win32.Registry.5.0.0\lib\net461\Microsoft.Win32.Registry.dll</HintPath>
     </Reference>
@@ -80,7 +83,7 @@
       <HintPath>packages\NAudio.WinMM.2.2.1\lib\netstandard2.0\NAudio.WinMM.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
@@ -88,8 +91,8 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.Security.AccessControl, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>packages\System.Security.AccessControl.6.0.0\lib\net461\System.Security.AccessControl.dll</HintPath>
+    <Reference Include="System.Security.AccessControl, Version=6.0.0.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\System.Security.AccessControl.6.0.1\lib\net461\System.Security.AccessControl.dll</HintPath>
     </Reference>
     <Reference Include="System.Security.Principal.Windows, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>packages\System.Security.Principal.Windows.5.0.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>

--- a/SyncRoomChatTool/app.manifest
+++ b/SyncRoomChatTool/app.manifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="0.0.2.0" name="MyApplication.app"/>
+  <assemblyIdentity version="0.0.2.1" name="MyApplication.app"/>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">

--- a/SyncRoomChatTool/packages.config
+++ b/SyncRoomChatTool/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="google-diff-match-patch" version="1.0.10" targetFramework="net472" />
   <package id="Microsoft.Win32.Registry" version="5.0.0" targetFramework="net472" />
   <package id="NAudio" version="2.2.1" targetFramework="net472" />
   <package id="NAudio.Asio" version="2.2.1" targetFramework="net472" />

--- a/SyncRoomChatTool/packages.config
+++ b/SyncRoomChatTool/packages.config
@@ -9,8 +9,8 @@
   <package id="NAudio.Wasapi" version="2.2.1" targetFramework="net472" />
   <package id="NAudio.WinForms" version="2.2.1" targetFramework="net472" />
   <package id="NAudio.WinMM" version="2.2.1" targetFramework="net472" />
-  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net472" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net472" />
-  <package id="System.Security.AccessControl" version="6.0.0" targetFramework="net472" />
+  <package id="System.Security.AccessControl" version="6.0.1" targetFramework="net472" />
   <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
取りこぼしがなくなったのと、SyncRoom起動中に読み上げちゃん再起動すると、最終行を読み上げてたのをチェックして読み上げないように変更。